### PR TITLE
setContentView() not required here.

### DIFF
--- a/app/src/main/java/com/acme/tictactoe/view/TicTacToeActivity.java
+++ b/app/src/main/java/com/acme/tictactoe/view/TicTacToeActivity.java
@@ -18,7 +18,6 @@ public class TicTacToeActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.tictactoe);
         TictactoeBinding binding = DataBindingUtil.setContentView(this, R.layout.tictactoe);
         binding.setViewModel(viewModel);
         viewModel.onCreate();


### PR DESCRIPTION
DataBindingUtil.setContentView() as well as returning the binding, it also sets the given layout as the content view of the given Activity.